### PR TITLE
allow users to try Ceu through Docker

### DIFF
--- a/etc/Dockerfile
+++ b/etc/Dockerfile
@@ -1,0 +1,13 @@
+# start with a current Debian image with some build tools installed
+FROM buildpack-deps:stretch
+
+# install dev packages for lua
+RUN apt-get update \
+  && apt-get install -y lua5.3 lua-lpeg liblua5.3-0 liblua5.3-dev \
+  && rm -rf /var/lib/apt/lists/*
+
+# shallow clone the repo, then build and install
+RUN git clone --depth 5 https://github.com/ceu-lang/ceu.git \
+  && cd ceu \
+  && make \
+  && make install


### PR DESCRIPTION
Have you considered using Docker to provide an easy way to let users try Ceu out?  If this image was pushed to the Docker Hub, new users would be able to run:

    docker run -it ceu

and Docker would take care of fetching everything, leaving them in a shell with `ceu` installed.

The commit message includes instructions on what to do, if you've not used this before.  I based it on the upstream image used by Python 3, which means it would be a ~20MB download if they already have that (I didn't see any up to date official Lua images).