### PR TITLE
add volatile keyword for optimizing compiler

### DIFF
--- a/src/c/ceu.c
+++ b/src/c/ceu.c
@@ -136,8 +136,8 @@ typedef struct tceu_code_mem {
 #ifdef CEU_FEATURES_THREAD
 typedef struct tceu_threads_data {
     CEU_THREADS_T id;
-    u8 has_started:    1;
-    u8 has_terminated: 1;
+    volatile u8 has_started:    1;
+    volatile u8 has_terminated: 1;
     u8 has_aborted:    1;
     u8 has_notified:   1;
     struct tceu_threads_data* nxt;


### PR DESCRIPTION
This takes care of issue #146 , but there are probably other areas that still might need to be protected from being optimized away.

For example, should the volatile keyword be added to any variables declared in the main thread, but made visible to the child thread?

And then there is the assignment in the child thread:
`_ceu_mem->_trails[2].evt.id = CEU_INPUT__NONE;`
Does that ever need to be protected?