### PR TITLE
Fixed async/thread bug

### DIFF
--- a/src/lua/codes.lua
+++ b/src/lua/codes.lua
@@ -1703,8 +1703,8 @@ if (]]..v..[[ != NULL)
         })
         LINE(me, [[
             {
-                CEU_THREADS_T** __ceu_casted = (CEU_THREADS_T**)_ceu_cur->params;
-                if (*(*(__ceu_casted)) == ]]..v..[[->id) {
+                CEU_THREADS_T* __ceu_casted = (CEU_THREADS_T*)_ceu_cur->params;
+                if (*(__ceu_casted) == ]]..v..[[->id) {
                     break; /* this thread is terminating */
                 }
             }


### PR DESCRIPTION
This should just be a pointer, not a pointer-to-pointer.
When a thread has exited, it emits the address of the thread-id to `CEU_INPUT__THREAD`, so only 1 deference should be used to get the thread-id back.