### PR TITLE
Update ceu.c : fix zero sized array

### DIFF
--- a/src/c/ceu.c
+++ b/src/c/ceu.c
@@ -130,7 +130,7 @@ typedef struct tceu_code_mem {
 #endif
     bool has_term;
     tceu_ntrl   trails_n;
-    tceu_trl    _trails[0];
+    tceu_trl    _trails[1];
 } tceu_code_mem;
 
 #ifdef CEU_FEATURES_THREAD


### PR DESCRIPTION
I don't think this array was intended to be zero sized. It was raising compiler warnings. From my use cases it looks like the array is expected to have a size of 1.