### PR TITLE
Add docker script to turn ceu into a binary file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 .*.swo
 .*.swp
+srlua/

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ LUA_EXE   = lua5.3
 CEU_EXE   = /usr/local/bin/ceu
 CEU_ARGS_ = --ceu-features-trace=true --ceu-err-unused=pass $(CEU_ARGS)
 CC_ARGS_  = -llua5.3 -lpthread $(CC_ARGS)
+GLUE_EXE  = /usr/local/bin/glue
+SRLUA_EXE = /usr/local/bin/srlua
 
 ###############################################################################
 # DO NOT EDIT
@@ -16,6 +18,22 @@ compiler:
 
 install:
 	install ./src/lua/ceu $(CEU_EXE)
+
+docker-build:
+	sudo docker build -t ceu -f ./etc/ceu-binary/Dockerfile .
+
+docker-install:
+	sudo docker run -v $(shell pwd)/bin:/ceu/bin/:z ceu
+
+install-srlua:
+	git clone https://github.com/LuaDist/srlua.git
+	cd srlua && sed -i 's/-ansi//g; s/-llua/-llua5.3/g; s/gcc/gcc -static/g' Makefile && make
+	install ./srlua/glue $(GLUE_EXE)
+	install ./srlua/srlua $(SRLUA_EXE)
+
+binary:
+	glue ./srlua/srlua ./src/lua/ceu ./bin/ceu.bin
+	chmod +x ./bin/ceu.bin
 
 one:
 	ceu --pre --pre-input=$(CEU_SRC) --pre-args=\"-I./include\"                \

--- a/etc/ceu-binary/Dockerfile
+++ b/etc/ceu-binary/Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:23.10
+
+WORKDIR /ceu
+
+RUN apt update
+RUN apt install -y git lua5.3 lua-lpeg liblua5.3-0 liblua5.3-dev make
+
+COPY . .
+
+RUN ln -s /usr/include/lua5.3/* /usr/local/include/
+
+CMD make && make install-srlua && make binary


### PR DESCRIPTION
## Why
Compiling Céu on Fedora 38 can be problematic, especially because the required Lua version is not available in the repository. So I decided to make a docker script to compile Céu for me, but little did I know that Céu was actually a Lua script. ☠️

#Solution
Recognizing that a static binary could simplify the execution of Céu, I started to look for a Graal-like VM for Lua until I stepped into a project that's been archived called [srlua](https://github.com/LuaDist/srlua.git), which glues Lua scripts with a LuaVM into a single and static binary.

That said, I should also mention that the ceu-script is only 414.6 KiB while ceu-bin is 1.8 MiB, which is aproximately 4.5 times bigger but you should also take into account that in this way you won't need a LuaVM to run the code.

1b181a9e: Add docker script to turn ceu into a binary file.
```
This commit adds the following rules to makefile:
	* docker-build: builds the docker container.
	* docker-install:
		- creates a shared directory called bin in the repository root;
		- installs srlua (project responsible for converting lua scripts into binary files);
		- builds the binary and outputs to `bin`.
```